### PR TITLE
Expand "show" for employee

### DIFF
--- a/lib/prm/employees/employees.ex
+++ b/lib/prm/employees/employees.ex
@@ -80,11 +80,7 @@ defmodule PRM.Employees do
   end
 
   def preload_relations(repo, %{"expand" => _}) when length(repo) > 0 do
-    repo
-    |> Repo.preload(:doctor)
-    |> Repo.preload(:party)
-    |> Repo.preload(:division)
-    |> Repo.preload(:legal_entity)
+    do_preload(repo)
   end
 
   def preload_relations(err, _params), do: err
@@ -92,13 +88,16 @@ defmodule PRM.Employees do
   def get_employee!(id) do
     Employee
     |> Repo.get!(id)
-    |> preload_references()
+    |> do_preload()
   end
 
-  def preload_references(%{employee_type: "DOCTOR"} = employee) do
-    Repo.preload(employee, :doctor)
+  defp do_preload(repo) do
+    repo
+    |> Repo.preload(:doctor)
+    |> Repo.preload(:party)
+    |> Repo.preload(:division)
+    |> Repo.preload(:legal_entity)
   end
-  def preload_references(employee), do: employee
 
   def create_employee(attrs \\ %{}, user_id) do
     %Employee{}

--- a/lib/prm/web/views/employee_view.ex
+++ b/lib/prm/web/views/employee_view.ex
@@ -33,6 +33,9 @@ defmodule PRM.Web.EmployeeView do
       updated_by: employee.updated_by,
       start_date: employee.start_date,
       end_date: employee.end_date,
+      party_id: employee.party_id,
+      legal_entity_id: employee.legal_entity_id,
+      division_id: employee.division_id
     }
     |> render_association(employee.party, :party, employee.party_id)
     |> render_association(employee.division, :division, employee.division_id)

--- a/test/web/controllers/employee_controller_test.exs
+++ b/test/web/controllers/employee_controller_test.exs
@@ -71,9 +71,6 @@ defmodule PRM.Web.EmployeeControllerTest do
     assert is_map(employee["party"])
     assert is_map(employee["division"])
     assert is_map(employee["legal_entity"])
-    refute Map.has_key?(employee, "party_id")
-    refute Map.has_key?(employee, "division_id")
-    refute Map.has_key?(employee, "legal_entity_id")
   end
 
   test "search employee by employee_type", %{conn: conn} do
@@ -154,7 +151,7 @@ defmodule PRM.Web.EmployeeControllerTest do
     assert %{"id" => id} = json_response(conn, 201)["data"]
 
     conn = get conn, employee_path(conn, :show, id)
-    assert json_response(conn, 200)["data"] == %{
+    assert %{
       "id" => id,
       "employee_type" => "hr",
       "is_active" => true,
@@ -167,7 +164,10 @@ defmodule PRM.Web.EmployeeControllerTest do
       "party_id" => party_id,
       "division_id" => division_id,
       "legal_entity_id" => legal_entity_id,
-    }
+      "party" => _,
+      "legal_entity" => _,
+      "division" => _
+    } = json_response(conn, 200)["data"]
   end
 
   test "does not create employee and renders errors when data is invalid", %{conn: conn} do


### PR DESCRIPTION
It must return full associated records.

After this change:

* `employee_get_by_id` – will return all records associated to employee,
* `employees` (search) – will return _id fields as well (this is a side-effect of the change).